### PR TITLE
Fix Array type internal definition

### DIFF
--- a/shared/src/main/scala/mlscript/Typer.scala
+++ b/shared/src/main/scala/mlscript/Typer.scala
@@ -160,7 +160,10 @@ class Typer(var dbg: Boolean, var verbose: Bool, var explainErrors: Bool) extend
     TypeDef(Als, TypeName("nothing"), Nil, Nil, BotType, Nil, Nil, Set.empty, N) ::
     TypeDef(Cls, TypeName("error"), Nil, Nil, TopType, Nil, Nil, Set.empty, N) ::
     TypeDef(Cls, TypeName("unit"), Nil, Nil, TopType, Nil, Nil, Set.empty, N) ::
-    TypeDef(Cls, TypeName("Array"), List(TypeName("A") -> freshVar(noProv)(1)) /* ??? */, Nil, TopType, Nil, Nil, Set.empty, N) ::
+    {
+      val tv = freshVar(noProv)(1)
+      TypeDef(Als, TypeName("Array"), List(TypeName("A") -> tv), Nil, ArrayType(tv)(noProv), Nil, Nil, Set.empty, N)
+    } ::
     Nil
   val primitiveTypes: Set[Str] =
     builtinTypes.iterator.filter(_.kind is Cls).map(_.nme.name).toSet

--- a/shared/src/test/diff/mlscript/Yicong.mls
+++ b/shared/src/test/diff/mlscript/Yicong.mls
@@ -308,54 +308,6 @@ q = if true then (1,1) else (1,1,1)
 //│ Array[1]
 //│   <:  q:
 //│ Array[int]
-//│ ╔══[ERROR] Type mismatch in def definition:
-//│ ║  l.306: 	q = if true then (1,1) else (1,1,1)
-//│ ║         	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-//│ ╟── expression of type `(1, 1,)` does not match type `Array[?]`
-//│ ║  l.306: 	q = if true then (1,1) else (1,1,1)
-//│ ║         	                  ^^^
-//│ ╟── but it flows into application with expected type `Array[int]`
-//│ ║  l.306: 	q = if true then (1,1) else (1,1,1)
-//│ ║         	       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-//│ ╟── Note: constraint arises from applied type reference:
-//│ ║  l.305: 	def q: Array[int]
-//│ ╙──       	       ^^^^^^^^^^
-//│ ╔══[ERROR] Type mismatch in def definition:
-//│ ║  l.306: 	q = if true then (1,1) else (1,1,1)
-//│ ║         	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-//│ ╟── expression of type `(1, 1,)` does not have field 'Array#A'
-//│ ║  l.306: 	q = if true then (1,1) else (1,1,1)
-//│ ║         	                  ^^^
-//│ ╟── but it flows into application with expected type `Array[int]`
-//│ ║  l.306: 	q = if true then (1,1) else (1,1,1)
-//│ ║         	       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-//│ ╟── Note: constraint arises from applied type reference:
-//│ ║  l.305: 	def q: Array[int]
-//│ ╙──       	       ^^^^^^^^^^
-//│ ╔══[ERROR] Type mismatch in def definition:
-//│ ║  l.306: 	q = if true then (1,1) else (1,1,1)
-//│ ║         	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-//│ ╟── expression of type `(1, 1, 1,)` does not match type `Array[?]`
-//│ ║  l.306: 	q = if true then (1,1) else (1,1,1)
-//│ ║         	                             ^^^^^
-//│ ╟── but it flows into application with expected type `Array[int]`
-//│ ║  l.306: 	q = if true then (1,1) else (1,1,1)
-//│ ║         	       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-//│ ╟── Note: constraint arises from applied type reference:
-//│ ║  l.305: 	def q: Array[int]
-//│ ╙──       	       ^^^^^^^^^^
-//│ ╔══[ERROR] Type mismatch in def definition:
-//│ ║  l.306: 	q = if true then (1,1) else (1,1,1)
-//│ ║         	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-//│ ╟── expression of type `(1, 1, 1,)` does not have field 'Array#A'
-//│ ║  l.306: 	q = if true then (1,1) else (1,1,1)
-//│ ║         	                             ^^^^^
-//│ ╟── but it flows into application with expected type `Array[int]`
-//│ ║  l.306: 	q = if true then (1,1) else (1,1,1)
-//│ ║         	       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-//│ ╟── Note: constraint arises from applied type reference:
-//│ ║  l.305: 	def q: Array[int]
-//│ ╙──       	       ^^^^^^^^^^
 //│  = [ 1, 1 ]
 
 def h f = (f (1,2,false), f (1,true))
@@ -374,30 +326,39 @@ fx q2
 //│ fx: (int, int, int,) -> int
 //│   = [Function: fx]
 //│ ╔══[ERROR] Type mismatch in application:
-//│ ║  l.368: 	fx q1
+//│ ║  l.320: 	fx q1
 //│ ║         	^^^^^
 //│ ╟── expression of type `(1, 1, 1, 1,)` does not match type `(?a, ?b, ?c,)`
-//│ ║  l.365: 	q1 = (1,1,1,1)
+//│ ║  l.317: 	q1 = (1,1,1,1)
 //│ ║         	      ^^^^^^^
 //│ ╟── but it flows into reference with expected type `(?d, ?e, ?f,)`
-//│ ║  l.368: 	fx q1
+//│ ║  l.320: 	fx q1
 //│ ║         	   ^^
 //│ ╟── Note: constraint arises from tuple literal:
-//│ ║  l.367: 	fx ((a,b,c)) = a + b + c
+//│ ║  l.319: 	fx ((a,b,c)) = a + b + c
 //│ ╙──       	     ^^^^^
 //│ res: error | int
 //│    = 3
 //│ ╔══[ERROR] Type mismatch in application:
-//│ ║  l.369: 	fx q2
+//│ ║  l.321: 	fx q2
 //│ ║         	^^^^^
 //│ ╟── expression of type `(1, 1,)` does not match type `(?a, ?b, ?c,)`
-//│ ║  l.366: 	q2 = (1,1)
+//│ ║  l.318: 	q2 = (1,1)
 //│ ║         	      ^^^
 //│ ╟── but it flows into reference with expected type `(?d, ?e, ?f,)`
-//│ ║  l.369: 	fx q2
+//│ ║  l.321: 	fx q2
 //│ ║         	   ^^
 //│ ╟── Note: constraint arises from tuple literal:
-//│ ║  l.367: 	fx ((a,b,c)) = a + b + c
+//│ ║  l.319: 	fx ((a,b,c)) = a + b + c
 //│ ╙──       	     ^^^^^
 //│ res: error | int
 //│    = NaN
+
+
+// :d
+q = (1,1)
+//│ (1, 1,)
+//│   <:  q:
+//│ Array[int]
+//│  = [ 1, 1 ]
+


### PR DESCRIPTION
The problem was that you were defining `"Array"` as being some class (`Cls`) unrelated with your internal `ArrayType` representation. I made it a _type alias_ (`Als`) of our internal representation here.

PS: It makes it easier for everyone if you create a new branch name for your changes (instead of keeping the main branch name `mlscript`).